### PR TITLE
Closes #139: update install instructions for gfortran under macOS

### DIFF
--- a/README_install.md
+++ b/README_install.md
@@ -12,9 +12,11 @@ It is recommended to use Anaconda, especially for Windows users. For this:
 
 - Then, to activate the environment, type `conda activate exostriker`;
 
-## Windows additional step
+## Additional step
 
-In order to compile the Fortran code of Exostriker when using Anaconda, install the Gfortran directly from the Anaconda repository:
+This is especially necessary for Windows and can also be needed for some new M-chip macOS users.
+
+Depending on the type of GFortran installation, anaconda might not be able to find it. In order to satisfactorily compile the Fortran code of Exostriker when using Anaconda, install the Gfortran directly from the Anaconda repository:
 
 ```bash
 conda install conda-forge::gfortran

--- a/exostriker/__init__.py
+++ b/exostriker/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.93.8"
+__version__ = "0.93.9"
 __author__ = "Trifon Trifonov"
 
 from exostriker import gui, lib


### PR DESCRIPTION
Update install instructions to warn macOS users to also install gfortran using the conda install process.